### PR TITLE
feat(html): Add `Html` component

### DIFF
--- a/packages/html/.eslintrc.js
+++ b/packages/html/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: ['custom'],
+};

--- a/packages/html/license.md
+++ b/packages/html/license.md
@@ -1,0 +1,8 @@
+Copyright 2022 Bu Kinoshita and Zeno Rocha
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@react-email/html",
   "version": "0.0.1",
-  "description": "A React HTML component to help build emails",
+  "description": "A React html component to wrap emails",
   "sideEffects": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@react-email/html",
+  "version": "0.0.1",
+  "description": "A React HTML component to help build emails",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist/**"
+  ],
+  "license": "MIT",
+  "scripts": {
+    "build": "tsup src/index.ts --format esm,cjs --dts --external react",
+    "dev": "tsup src/index.ts --format esm,cjs --dts --external react --watch",
+    "lint": "TIMING=1 eslint src/**/*.ts* --fix",
+    "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "@types/react": "18.0.20",
+    "@types/react-dom": "18.0.6",
+    "eslint": "8.23.1",
+    "eslint-config-custom": "*",
+    "react": "18.2.0",
+    "tsconfig": "*",
+    "tsup": "6.2.3",
+    "typescript": "4.8.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/html/readme.md
+++ b/packages/html/readme.md
@@ -1,0 +1,51 @@
+![React Email HTML cover](https://react-email-assets.vercel.app/html.png)
+
+<div align="center"><strong>@react-email/html</strong></div>
+<div align="center">A React HTML component to help build emails.</div>
+<br />
+<div align="center">
+<a href="https://react.email">Website</a> 
+<span> · </span>
+<a href="https://react.email">Documentation</a> 
+<span> · </span>
+<a href="https://react.email">Twitter</a>
+</div>
+
+## Install
+
+Install component from your command line.
+
+#### With yarn
+
+```sh
+yarn add @react-email/html -E
+```
+
+#### With npm
+
+```sh
+npm install @react-email/html -E
+```
+
+## Getting started
+
+Add the component to your email template. Include styles where needed.
+
+```jsx
+import { Button } from '@react-email/button';
+import { Html } from '@react-email/html';
+
+const Email = () => {
+  return (
+    <Html lang="en">
+      <Button href="https://example.com" style={{ color: '#61dafb' }}>
+        Click me
+      </Button>
+    </Html>
+  );
+};
+```
+
+## License
+
+MIT License

--- a/packages/html/readme.md
+++ b/packages/html/readme.md
@@ -1,7 +1,7 @@
 ![React Email HTML cover](https://react-email-assets.vercel.app/html.png)
 
 <div align="center"><strong>@react-email/html</strong></div>
-<div align="center">A React HTML component to help build emails.</div>
+<div align="center">A React html component to wrap emails.</div>
 <br />
 <div align="center">
 <a href="https://react.email">Website</a> 

--- a/packages/html/src/html.tsx
+++ b/packages/html/src/html.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+type RootProps = React.ComponentPropsWithoutRef<'html'>;
+
+export interface HtmlProps extends RootProps {}
+
+export const Html: React.FC<Readonly<HtmlProps>> = ({
+  children,
+  style,
+  ...props
+}) => <html {...props}>{children}</html>;
+
+Html.displayName = 'Html';

--- a/packages/html/src/html.tsx
+++ b/packages/html/src/html.tsx
@@ -6,8 +6,13 @@ export interface HtmlProps extends RootProps {}
 
 export const Html: React.FC<Readonly<HtmlProps>> = ({
   children,
+  lang = 'en',
   style,
   ...props
-}) => <html {...props}>{children}</html>;
+}) => (
+  <html lang={lang} {...props}>
+    {children}
+  </html>
+);
 
 Html.displayName = 'Html';

--- a/packages/html/src/index.ts
+++ b/packages/html/src/index.ts
@@ -1,0 +1,1 @@
+export * from './html';

--- a/packages/html/tsconfig.json
+++ b/packages/html/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "lib": ["dom", "ES2015"]
+  },
+  "extends": "tsconfig/react-library.json",
+  "include": ["."],
+  "exclude": ["dist", "build", "node_modules"]
+}


### PR DESCRIPTION
Closes https://github.com/zenorocha/react-email/issues/9

> Note: Saw some references to use `xmlns="http://www.w3.org/1999/xhtml"` on the HTML tag, but got some Typescript complains about it. So, not really sure if it's really necessary.

<img width="634" alt="screenshot 2022-09-21 at 22 30 27@2x" src="https://user-images.githubusercontent.com/6929565/191638581-6a04415d-78c3-404d-bc16-6f02cebc8be3.png">

