### PR TITLE
fix(Avatar): change abbreviete to abbreviate

### DIFF
--- a/packages/avatar/src/avatar.tsx
+++ b/packages/avatar/src/avatar.tsx
@@ -81,13 +81,13 @@ export const AvatarFallback = React.forwardRef<
     ref={forwardedRef}
     {...props}
   >
-    {abbreviete(children)}
+    {abbreviate(children)}
   </span>
 ));
 
 AvatarFallback.displayName = 'AvatarFallback';
 
-const abbreviete = (fallback: any): string => {
+const abbreviate = (fallback: any): string => {
   const text = fallback.toString();
   if (!text) {
     return '';


### PR DESCRIPTION
Not sure if it was intentionally written in 🇮🇹 , or was a mistake.
I opened this small contribution by changing it to how we write in 🇺🇸 .