### PR TITLE
fix: remove td tag and add default style for tr tag

### DIFF
--- a/packages/section/src/section.tsx
+++ b/packages/section/src/section.tsx
@@ -9,15 +9,21 @@ export interface SectionProps extends RootProps {
 
 export const Section = React.forwardRef<SectionElement, Readonly<SectionProps>>(
   ({ children, style, ...props }, forwardedRef) => {
-    const styleDefault = {
+    const styleDefaultTable = {
       width: '100%',
       ...style,
     };
 
+    const styleDefaultTr = {
+      display: 'grid',
+      gridAutoColumns: 'minmax(0, 1fr)', 
+      gridAutoFlow: 'column',
+    }
+
     return (
       <table
         ref={forwardedRef}
-        style={styleDefault}
+        style={styleDefaultTable}
         align="center"
         border={0}
         cellPadding={0}
@@ -26,8 +32,8 @@ export const Section = React.forwardRef<SectionElement, Readonly<SectionProps>>(
         {...props}
       >
         <tbody>
-          <tr>
-            <td>{children}</td>
+          <tr style={styleDefaultTr}>
+            {children}
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
This PR simplifies the Section component to always receive a column (one or several) as children and organize them in the best way, with the same sizes and spacing.

In short, the Section component will be responsible for creating a line and the Column component for dividing this line into columns.

Here's the example with static HTML.
https://codesandbox.io/s/section-and-column-example-lic7bh?file=/index.html

Issue:
https://github.com/zenorocha/react-email/issues/217