### PR TITLE
fix(react-email): Split path separator on Windows

### DIFF
--- a/packages/react-email/source/utils/watcher.ts
+++ b/packages/react-email/source/utils/watcher.ts
@@ -19,7 +19,7 @@ export const watcherInstance = chokidar.watch(CLIENT_EMAILS_PATH, {
 export const watcher = () =>
   watcherInstance.on('all', async (event, filename) => {
     if (event === EVENT_FILE_DELETED) {
-      const file = filename.split('/');
+      const file = filename.split(path.sep);
 
       if (file[1] === 'static') {
         if (file[2]) {
@@ -32,7 +32,7 @@ export const watcher = () =>
 
       await fs.promises.rm(path.join(REACT_EMAIL_ROOT, filename));
     } else {
-      const file = filename.split('/');
+      const file = filename.split(path.sep);
 
       if (file[1] === 'static') {
         await copy(


### PR DESCRIPTION
Using the `dev` (`email dev`) command on Windows now throws the following error:

```
node:internal/process/promises:288
            triggerUncaughtException(err, true /* fromPromise */);
            ^
NestedError: Cannot copy `M:\path\to\react-email-starter\emails/undefined`: the file doesn't exist
    at M:\path\to\react-email-starter\node_modules\cpy\index.js:96:10
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async FSWatcher.<anonymous> (M:\path\to\react-email-starter\node_modules\react-email\dist\utils\watcher.js:34:9) {
  nested: undefined,
  name: 'CpyError'
}
```

This is because Windows sets the path separator as "\\" instead of "/".  
Thus, it appears that the `file[1]` being accessed on the last line is `undefined`, and the command is crashing.