### PR TITLE
fix(Section): revert `Section` to version 0.0.3

### DIFF
--- a/packages/column/src/__snapshots__/column.spec.tsx.snap
+++ b/packages/column/src/__snapshots__/column.spec.tsx.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`render renders the <Column> component 1`] = `"<!DOCTYPE htmlPUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><td style=\\"width:100%;display:flex;justify-content:center;align-items:center\\" role=\\"presentation\\">Lorem ipsum</td>"`;
+exports[`render renders the <Column> component 1`] = `"<!DOCTYPE htmlPUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><td style=\\"display:inline-flex;justify-content:center;align-items:center\\" role=\\"presentation\\">Lorem ipsum</td>"`;

--- a/packages/section/src/__snapshots__/section.spec.tsx.snap
+++ b/packages/section/src/__snapshots__/section.spec.tsx.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`render renders the <Section> component 1`] = `"<!DOCTYPE htmlPUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><table style=\\"width:100%\\" align=\\"center\\" border=\\"0\\" cellPadding=\\"0\\" cellSpacing=\\"0\\" role=\\"presentation\\"><tbody><tr style=\\"display:grid;grid-auto-columns:minmax(0, 1fr);grid-auto-flow:column\\"><td>Lorem ipsum</td></tr></tbody></table>"`;
+exports[`render renders the <Section> component 1`] = `"<!DOCTYPE htmlPUBLIC \\"-//W3C//DTD XHTML 1.0 Transitional//EN\\" \\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\\"><table style=\\"width:100%\\" align=\\"center\\" border=\\"0\\" cellPadding=\\"0\\" cellSpacing=\\"0\\" role=\\"presentation\\"><tbody><tr style=\\"display:grid;grid-auto-columns:minmax(0, 1fr);grid-auto-flow:column\\">Lorem ipsum</tr></tbody></table>"`;

--- a/packages/section/src/section.spec.tsx
+++ b/packages/section/src/section.spec.tsx
@@ -11,22 +11,4 @@ describe('render', () => {
     const actualOutput = render(<Section>Lorem ipsum</Section>);
     expect(actualOutput).toMatchSnapshot();
   });
-
-  it('renders the <Section> with <td> wrapper if no <Column> is provided', () => {
-    const actualOutput = render(
-      <Section>
-        <div>Lorem ipsum</div>
-      </Section>
-    );
-    expect(actualOutput).toContain("<td>");
-  });
-
-  it('renders the <Section> with <td> wrapper if <Column> is provided', () => {
-    const actualOutput = render(
-      <Section>
-        <td>Lorem ipsum</td>
-      </Section>
-    );
-    expect(actualOutput).toContain("<td>");
-  });
 });

--- a/packages/section/src/section.tsx
+++ b/packages/section/src/section.tsx
@@ -20,16 +20,6 @@ export const Section = React.forwardRef<SectionElement, Readonly<SectionProps>>(
       gridAutoFlow: 'column',
     };
 
-    const arrayChildren = React.Children.toArray(children);
-
-    const hasTdElement = (child: React.ReactNode) => {
-      return React.isValidElement(child) && child.type === "td";
-    };
-  
-    const finalChildren = arrayChildren.map((child, index) => {
-      return hasTdElement(child) ? child : <td key={index}>{child}</td>;
-    });
-
     return (
       <table
         ref={forwardedRef}
@@ -42,7 +32,7 @@ export const Section = React.forwardRef<SectionElement, Readonly<SectionProps>>(
         {...props}
       >
         <tbody>
-          <tr style={styleDefaultTr}>{finalChildren}</tr>
+          <tr style={styleDefaultTr}>{children}</tr>
         </tbody>
       </table>
     );


### PR DESCRIPTION
This PR removes the logic responsible for inserting `<td>` tags for the children of the `<Section>` component. The component goes back to the previous version 0.0.3.

![Screenshot 2022-12-29 at 16 55 41](https://user-images.githubusercontent.com/8185819/209984711-607ab7b4-854c-4032-b042-47f82759acee.png)
