### PR TITLE
feat(react-email): Detect package manager in  command

### DIFF
--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -34,7 +34,7 @@
     "chokidar": "3.5.3",
     "commander": "9.4.1",
     "cpy": "8.1.2",
-    "detect-package-manager": "^2.0.1",
+    "detect-package-manager": "2.0.1",
     "esbuild": "0.16.4",
     "glob": "8.0.3",
     "log-symbols": "4.1.0",

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -34,6 +34,7 @@
     "chokidar": "3.5.3",
     "commander": "9.4.1",
     "cpy": "8.1.2",
+    "detect-package-manager": "^2.0.1",
     "esbuild": "0.16.4",
     "glob": "8.0.3",
     "log-symbols": "4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2626,6 +2626,13 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
+detect-package-manager@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/detect-package-manager/-/detect-package-manager-2.0.1.tgz#6b182e3ae5e1826752bfef1de9a7b828cffa50d8"
+  integrity sha512-j/lJHyoLlWi6G1LDdLgvUtz60Zo5GEj+sVYtTVXnYLDPuzgC3llMxonXym9zIwhhUII8vjdw0LXxavpLqTbl1A==
+  dependencies:
+    execa "^5.1.1"
+
 devtools-protocol@0.0.1068969:
   version "0.0.1068969"
   resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.1068969.tgz#8b9a4bc48aed1453bed08d62b07481f9abf4d6d8"
@@ -3393,7 +3400,7 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-execa@^5.0.0:
+execa@^5.0.0, execa@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
   integrity sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==
@@ -6084,10 +6091,10 @@ react-dom@18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
-react-email@1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/react-email/-/react-email-1.4.0.tgz#1a50f48e897000397878c4eb37d238597e9f7868"
-  integrity sha512-rqg2uF8Z910IASLAu2fYHE73R9vVuOFM+8NJi0r5P4EwIUGGzFgaAD3wA9r/JNGhUWVUS4EV5CX7NqClC8tZTQ==
+react-email@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/react-email/-/react-email-1.5.0.tgz#1d33f616a5295b7d440950c7c4bfe35e44822253"
+  integrity sha512-KdChjRPF+KoijftXA2NDCtLf1NoqtyqU9rlVnlHbcr5ItxvEB5PfaEQCrFHKS49AOFHfwUw0FwQoVfpUmXCyzg==
   dependencies:
     "@commander-js/extra-typings" "9.4.1"
     "@react-email/render" "*"
@@ -6100,6 +6107,7 @@ react-email@1.4.0:
     ora "5.4.1"
     read-pkg "5.2.0"
     shelljs "0.8.5"
+    tree-node-cli "^1.6.0"
 
 react-is@^16.13.1:
   version "16.13.1"
@@ -7002,7 +7010,7 @@ tree-kill@^1.2.2:
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
 
-tree-node-cli@1.6.0:
+tree-node-cli@1.6.0, tree-node-cli@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/tree-node-cli/-/tree-node-cli-1.6.0.tgz#15b76fd7381be650746f5ea06bd70049a3448c08"
   integrity sha512-M8um5Lbl76rWU5aC8oOeEhruiCM29lFCKnwpxrwMjpRicHXJx+bb9Cak11G3zYLrMb6Glsrhnn90rHIzDJrjvg==


### PR DESCRIPTION
Ideally, running `email dev` should install packages with the user's preferred package manager.

With `detect-package-manager`, this change first attempts to detect the PM based on the lockfile. If none exists, it checks for global installation of `yarn`, then `pnpm`. If neither of those are installed, it defaults to `npm` which is already installed with Node. See https://github.com/egoist/detect-package-manager/blob/main/src/index.ts.

Closes https://github.com/zenorocha/react-email/issues/246