### PR TITLE
fix(react-email): cli crash

### DIFF
--- a/packages/react-email/source/commands/dev.ts
+++ b/packages/react-email/source/commands/dev.ts
@@ -111,7 +111,9 @@ const createAppFiles = async () => {
         : `${SRC_PATH}/pages/${page.title}`;
 
       if (page.dir) {
-        createDirectory(`${SRC_PATH}/pages/${page.dir}`);
+        return createDirectory(`${SRC_PATH}/pages/${page.dir}`).then(() =>
+          fs.promises.writeFile(location, page.content),
+        );
       }
 
       return fs.promises.writeFile(location, page.content);

--- a/packages/react-email/source/commands/dev.ts
+++ b/packages/react-email/source/commands/dev.ts
@@ -105,15 +105,13 @@ const createAppFiles = async () => {
       });
     };
 
-    const pageCreation = pages.map((page) => {
+    const pageCreation = pages.map(async (page) => {
       const location = page.dir
         ? `${SRC_PATH}/pages/${page.dir}/${page.title}`
         : `${SRC_PATH}/pages/${page.title}`;
 
       if (page.dir) {
-        return createDirectory(`${SRC_PATH}/pages/${page.dir}`).then(() =>
-          fs.promises.writeFile(location, page.content),
-        );
+        await createDirectory(`${SRC_PATH}/pages/${page.dir}`);
       }
 
       return fs.promises.writeFile(location, page.content);


### PR DESCRIPTION
When running `react-email dev` on fresh project, there was error occured sometimes. And error was occured when `createAppFiles` function creating `./react-email/src/pages/preview/[slug].tsx` file, because `writeFile` function doesn't wait `createDirectory` function to finish.